### PR TITLE
v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ nodecg setup
 ```
 
 ## Usage
-* `nodecg setup [version]`, install a new instance of NodeCG; defaults to `latest`
+* `nodecg setup [version] [--update]`, install a new instance of NodeCG; defaults to `latest`. Enable `--update` flag to install over an existing copy of NodeCG.
 * `nodecg config`, interactively generate a new NodeCG config file (WIP, feedback wanted)
 * `nodecg start`, start the NodeCG instance in this directory path
 * `nodecg init`, interactively generate a new NodeCG bundle template (WIP, feedback wanted)
 * `nodecg install [repo] [--dev]`, install a bundle by cloning a git repo. Can be a GitHub owner/repo pair (`supportclass/lfg-sublistener`) or https git url (`https://github.com/SupportClass/lfg-sublistener.git`).
 If run in a bundle directory with no arguments, installs that bundle's dependencies. Enable `--dev` flag to install the bundle's `devDependencies`.
-* `nodecg update`, `git pull` a bundle. If run with no arguments, attempts to update the bundle in the current directory (if any)
+* `nodecg update [bundle|*] [--dev]`, `git pull` a bundle. Use `*` to update all installed bundles. Re-installs the bundles `dependencies` after updating.
+If run with no arguments, attempts to update the bundle in the current directory (if any). Enable `--dev` flag to install the bundle's `devDependencies`.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 [NodeCG](https://github.com/nodecg/nodecg)'s command line interface.
 
 ## Installation
-`npm install -g nodecg-cli`
+First, make sure you have [git](http://git-scm.com/) installed, and that it is in your PATH. Then, install via npm:
+```sh
+$ npm install -g nodecg-cli
+````
 
 Installing `nodecg-cli` does not install `NodeCG`. To install an instance of `NodeCG`, use the `setup` command in an empty directory:
-```
-mkdir nodecg
-cd nodecg
-nodecg setup
+```sh
+$ mkdir nodecg
+$ cd nodecg
+$ nodecg setup
 ```
 
 ## Usage

--- a/commands/install.js
+++ b/commands/install.js
@@ -56,7 +56,7 @@ module.exports = function installCommand(program) {
 
                 var write = process.stderr.write;
                 Q.Promise(function(resolve, reject) {
-                    process.stdout.write('Installing ' + bundleName + '...');
+                    process.stdout.write('Installing ' + bundleName + '... ');
 
                     // Make git be quiet
                     process.stderr.write = function(){};
@@ -66,12 +66,12 @@ module.exports = function installCommand(program) {
                         process.stderr.write = write;
 
                         if (err) {
-                            process.stdout.write(chalk.red(' failed!') + os.EOL);
+                            process.stdout.write(chalk.red('failed!') + os.EOL);
                             reject(err);
                             return;
                         }
 
-                        process.stdout.write(chalk.green(' done!') + os.EOL);
+                        process.stdout.write(chalk.green('done!') + os.EOL);
                         resolve();
                     });
                 })

--- a/commands/install.js
+++ b/commands/install.js
@@ -1,11 +1,15 @@
 'use strict';
 
 var fs = require('fs');
-var clone = require('nodegit').Clone.clone;
+var os = require('os');
 var installDeps = require('../lib/install-deps');
+var exec = require('child_process').exec;
 var npa = require('npm-package-arg');
 var path = require('path');
 var util = require('../lib/util');
+var format = require('util').format;
+var Q = require('q');
+var chalk = require('chalk');
 
 module.exports = function installCommand(program) {
     program
@@ -28,16 +32,11 @@ module.exports = function installCommand(program) {
             } else {
                 var parsed = npa(repo);
                 var repoUrl = null;
-                var opts = {};
 
                 if (parsed.type === 'git') {
+                    // TODO: This line was meant to accomodate nodegit, which is no longer used. Is is still needed?
                     repoUrl = parsed.spec.replace('+https', ''); //nodegit doesn't support git+https:// addresses
                 } else if (parsed.type === 'hosted') {
-                    // Github SSL cert isn't trusted by nodegit on OS X d-(^_^)z
-                    if (process.platform === 'darwin') {
-                        opts.ignoreCertErrors = 1;
-                    }
-
                     repoUrl = parsed.hosted.httpsUrl;
                 } else {
                     console.error('Please enter a valid git url (https) or GitHub username/repo pair.');
@@ -55,12 +54,33 @@ module.exports = function installCommand(program) {
                 var bundleName = temp.substr(0, temp.length - 4);
                 var bundlePath = path.join(nodecgPath, 'bundles/', bundleName);
 
-                clone(repoUrl, bundlePath, opts)
-                    .then(function(repo) {
-                        installDeps(bundlePath, dev);
+                var write = process.stderr.write;
+                Q.Promise(function(resolve, reject) {
+                    process.stdout.write('Installing ' + bundleName + '...');
+
+                    // Make git be quiet
+                    process.stderr.write = function(){};
+
+                    var cmdline = format('git clone %s "%s"', repoUrl, bundlePath);
+                    exec(cmdline, function(err, stdout, stderr) {
+                        process.stderr.write = write;
+
+                        if (err) {
+                            process.stdout.write(chalk.red(' failed!') + os.EOL);
+                            reject(err);
+                            return;
+                        }
+
+                        process.stdout.write(chalk.green(' done!') + os.EOL);
+                        resolve();
+                    });
+                })
+                    .then(function() {
+                        return installDeps(bundlePath, dev);
                     })
                     .catch(function(err) {
-                        console.error(err.stack);
+                        process.stderr.write = write;
+                        console.error(err.message);
                         process.exit(1);
                     });
             }

--- a/commands/install.js
+++ b/commands/install.js
@@ -24,7 +24,6 @@ module.exports = function installCommand(program) {
             }
 
             var dev = options.dev || false;
-
             if (!repo) {
                 // If no args are supplied, assume the user is intending to operate on the bundle in the current dir
                 installDeps(process.cwd(), dev)
@@ -42,8 +41,8 @@ module.exports = function installCommand(program) {
                     process.exit(1);
                 }
 
+                // Check that `bundles` exists
                 var bundlesPath = path.join(nodecgPath, 'bundles');
-                // Check that bundles exists
                 if (!fs.existsSync(bundlesPath)) {
                     fs.mkdirSync(bundlesPath);
                 }

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -200,7 +200,6 @@ module.exports = function initCommand(program) {
                     process.stdout.write('Installing production npm dependencies... ');
                     var deferred = Q.defer();
                     exec('npm install --production', {}, function(err, stdout, stderr) {
-                        if (stderr) console.error(stderr);
                         if (err) {
                             process.stdout.write(chalk.red('failed!') + os.EOL);
                             deferred.reject(err);

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -2,10 +2,8 @@
 
 var util = require('../lib/util');
 var childProcess = require('child_process');
-var exec = childProcess.exec;
 var execSync = childProcess.execSync;
 var os = require('os');
-var Q = require('q');
 var chalk = require('chalk');
 var inquirer = require('inquirer');
 
@@ -17,9 +15,6 @@ module.exports = function initCommand(program) {
         .option('-u, --update', 'Update the local NodeCG installation')
         .description('Install a new NodeCG instance')
         .action(function(version, options) {
-            // We'll need this for later...
-            var write = process.stderr.write;
-
             // We prefix our release tags with 'v'
             if (version && version.charAt(0) !== 'v') {
                 version = 'v' + version;
@@ -34,8 +29,8 @@ module.exports = function initCommand(program) {
                 }
 
                 // Fetch the latest tags from GitHub
+                process.stdout.write('Fetching the list of releases... ');
                 try {
-                    process.stdout.write('Fetching the list of releases... ');
                     execSync('git fetch');
                     process.stdout.write(chalk.green('done!') + os.EOL);
                 } catch (e) {

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -23,11 +23,11 @@ module.exports = function initCommand(program) {
                 version = 'v' + version;
             }
 
-            // If NodeCG is already installed and the `-f` flag was supplied, update NodeCG
+            // If NodeCG is already installed and the `-u` flag was supplied, update NodeCG
             if (util.pathContainsNodeCG(process.cwd())) {
                 if (!options.update) {
                     console.log('NodeCG is already installed in this directory.');
-                    console.log('Use ' + chalk.cyan('nodecg setup -u') + ' to update your existing install.');
+                    console.log('Use ' + chalk.cyan('nodecg setup [version] -u') + ' if you want update your existing install.');
                     process.exit(0);
                 }
 

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -27,7 +27,7 @@ module.exports = function initCommand(program) {
 
             var write = process.stderr.write;
             Q.Promise(function(resolve, reject) {
-                process.stdout.write('Cloning NodeCG...');
+                process.stdout.write('Cloning NodeCG... ');
 
                 // Shh git...
                 process.stderr.write = function(){};
@@ -36,12 +36,12 @@ module.exports = function initCommand(program) {
                     process.stderr.write = write;
 
                     if (err) {
-                        process.stdout.write(chalk.red(' failed!') + os.EOL);
+                        process.stdout.write(chalk.red('failed!') + os.EOL);
                         reject(err);
                         return;
                     }
 
-                    process.stdout.write(chalk.green(' done!') + os.EOL);
+                    process.stdout.write(chalk.green('done!') + os.EOL);
                     resolve();
                 });
             })
@@ -53,35 +53,35 @@ module.exports = function initCommand(program) {
                     // Shh git...
                     process.stderr.write = function(){};
 
-                    process.stdout.write('Checking out version ' + version + '...');
+                    process.stdout.write('Checking out version ' + version + '... ');
 
                     // If a specific version tag argument was supplied, check out that tag
                     exec('git checkout ' + version, function(err, stdout, stderr) {
                         process.stderr.write = write;
 
                         if (err) {
-                            process.stdout.write(chalk.red(' failed!') + os.EOL);
+                            process.stdout.write(chalk.red('failed!') + os.EOL);
                             deferred.reject(err);
                             return;
                         }
 
-                        process.stdout.write(chalk.green(' done!') + os.EOL);
+                        process.stdout.write(chalk.green('done!') + os.EOL);
                         deferred.resolve();
                     });
 
                     return deferred.promise;
                 })
                 .then(function(){
-                    process.stdout.write('Installing production npm dependencies...');
+                    process.stdout.write('Installing production npm dependencies... ');
                     var deferred = Q.defer();
                     exec('npm install --production', {}, function(err, stdout, stderr) {
                         if (stderr) console.error(stderr);
                         if (err) {
-                            process.stdout.write(chalk.red(' failed!') + os.EOL);
+                            process.stdout.write(chalk.red('failed!') + os.EOL);
                             deferred.reject(err);
                             return;
                         }
-                        process.stdout.write(chalk.green(' done!') + os.EOL);
+                        process.stdout.write(chalk.green('done!') + os.EOL);
                         deferred.resolve();
                     });
                     return deferred.promise;

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -47,9 +47,7 @@ module.exports = function initCommand(program) {
                 })
                     .then(function() {
                         var deferred = Q.defer();
-
-                        // Shh git...
-                        process.stderr.write = function(){};
+                        process.stderr.write = function(){}; // Shh git...
 
                         // If no version is supplied, assume they want the latest release
                         if (!version) {
@@ -79,7 +77,6 @@ module.exports = function initCommand(program) {
 
                             // Now that we know our version exists, our target is either the version or the newest tag.
                             var target = version || tags.pop();
-
                             process.stdout.write(chalk.green('done!') + os.EOL);
 
                             if (target < current) {
@@ -108,12 +105,8 @@ module.exports = function initCommand(program) {
                         }
 
                         var deferred = Q.defer();
-
-                        // Shh git...
-                        process.stderr.write = function(){};
-
+                        process.stderr.write = function(){}; // Shh git...
                         process.stdout.write('Updating from '+chalk.magenta(result.current)+' to '+chalk.magenta(result.target)+'... ');
-
                         exec('git pull origin master', function(err, stdout, stderr) {
                             if (err) {
                                 process.stdout.write(chalk.red('failed!') + os.EOL);
@@ -151,9 +144,7 @@ module.exports = function initCommand(program) {
 
             Q.Promise(function(resolve, reject) {
                 process.stdout.write('Cloning NodeCG... ');
-
-                // Shh git...
-                process.stderr.write = function(){};
+                process.stderr.write = function(){}; // Shh git...
 
                 exec('git clone ' + NODECG_GIT_URL + ' .', function(err, stdout, stderr) {
                     process.stderr.write = write;
@@ -172,10 +163,7 @@ module.exports = function initCommand(program) {
                     if (!version) return;
 
                     var deferred = Q.defer();
-
-                    // Shh git...
-                    process.stderr.write = function(){};
-
+                    process.stderr.write = function(){}; // Shh git...
                     process.stdout.write('Checking out version ' + version + '... ');
 
                     // If a specific version tag argument was supplied, check out that tag

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -12,12 +12,113 @@ var NODECG_GIT_URL = 'https://github.com/nodecg/nodecg.git';
 module.exports = function initCommand(program) {
     program
         .command('setup [version]')
+        .option('-u, --update', 'Update the local NodeCG installation')
         .description('Install a new NodeCG instance')
-        .action(function(version) {
-            // Check if nodecg is already installed
+        .action(function(version, options) {
+            // We'll need this for later...
+            var write = process.stderr.write;
+
+            // If NodeCG is already installed and the `-f` flag was supplied, update NodeCG
             if (util.pathContainsNodeCG(process.cwd())) {
-                console.log('NodeCG is already installed in this directory');
-                process.exit(0);
+                if (!options.update) {
+                    console.log('NodeCG is already installed in this directory.');
+                    console.log('Use ' + chalk.cyan('nodecg setup -u') + ' to update your existing install');
+                    process.exit(0);
+                }
+
+                // Fetch the latest tags
+                // Then pull the latest tag
+                Q.Promise(function(resolve, reject) {
+                    process.stdout.write('Fetching the list of releases... ');
+
+                    exec('git fetch', function(err, stdout, stderr) {
+                        if (err) {
+                            process.stdout.write(chalk.red('failed!') + os.EOL);
+                            reject(err);
+                            return;
+                        }
+
+                        process.stdout.write(chalk.green('done!') + os.EOL);
+                        resolve();
+                    });
+                })
+                    .then(function() {
+                        var deferred = Q.defer();
+
+                        // Shh git...
+                        process.stderr.write = function(){};
+
+                        process.stdout.write('Checking against local install for updates... ');
+
+                        exec('git tag', function(err, stdout, stderr) {
+                            process.stderr.write = write;
+
+                            if (err) {
+                                process.stdout.write(chalk.red('failed!') + os.EOL);
+                                deferred.reject(err);
+                                return;
+                            }
+
+                            var tags = stdout.trim().split('\n');
+                            var latest = tags.pop();
+                            var current = require(process.cwd() + '/package.json').version;
+
+                            process.stdout.write(chalk.green('done!') + os.EOL);
+                            deferred.resolve({
+                                needsUpdate: latest.replace('v', '') !== current,
+                                current: current,
+                                latest: latest
+                            });
+                        });
+
+                        return deferred.promise;
+                    })
+                    .then(function(result) {
+                        if (!result.needsUpdate) {
+                            console.log('No updates found! Your current version (%s) is the latest.', chalk.magenta(result.current));
+                            return;
+                        }
+
+                        var deferred = Q.defer();
+
+                        // Shh git...
+                        //process.stderr.write = function(){};
+
+                        process.stdout.write('Updating from v'+chalk.magenta(result.current)+' to '+chalk.magenta(result.latest)+'... ');
+
+                        exec('git pull origin master', function(err, stdout, stderr) {
+                            if (err) {
+                                process.stdout.write(chalk.red('failed!') + os.EOL);
+                                deferred.reject(err);
+                                return;
+                            }
+
+                            exec('git checkout ' + result.latest, function(err, stdout, stderr) {
+                                process.stderr.write = write;
+
+                                if (err) {
+                                    process.stdout.write(chalk.red('failed!') + os.EOL);
+                                    deferred.reject(err);
+                                    return;
+                                }
+
+                                process.stdout.write(chalk.green('done!') + os.EOL);
+                                deferred.resolve(result.latest);
+                            });
+                        });
+
+                        return deferred.promise;
+                    })
+                    .catch(function(e) {
+                        process.stderr.write = write;
+                        console.error('Failed to update NodeCG:', os.EOL, e.message);
+                    })
+                    .done(function(latest) {
+                        if (latest) {
+                            console.log('NodeCG updated to', chalk.magenta(latest));
+                        }
+                    });
+                return;
             }
 
             // We prefix our release tags with 'v'
@@ -25,7 +126,6 @@ module.exports = function initCommand(program) {
                 version = 'v' + version;
             }
 
-            var write = process.stderr.write;
             Q.Promise(function(resolve, reject) {
                 process.stdout.write('Cloning NodeCG... ');
 

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -53,10 +53,10 @@ module.exports = function initCommand(program) {
                         var deferred = Q.defer();
                         process.stderr.write = function(){}; // Shh git...
 
-                        if (!version) {
-                            process.stdout.write('Checking against local install for updates... ');
-                        } else {
+                        if (version) {
                             process.stdout.write('Searching for release '+chalk.magenta(version)+' ... ');
+                        } else {
+                            process.stdout.write('Checking against local install for updates... ');
                         }
 
 
@@ -216,7 +216,7 @@ module.exports = function initCommand(program) {
                     process.stderr.write = write;
                    console.error('Failed to setup NodeCG:', os.EOL, e.message);
                 })
-                
+
                 .done(function() {
                     console.log('NodeCG (%s) installed to', version ? version : 'latest', process.cwd());
                 });

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -3,9 +3,11 @@
 var util = require('../lib/util');
 var childProcess = require('child_process');
 var exec = childProcess.exec;
+var execSync = childProcess.execSync;
 var os = require('os');
 var Q = require('q');
 var chalk = require('chalk');
+var inquirer = require('inquirer');
 
 var NODECG_GIT_URL = 'https://github.com/nodecg/nodecg.git';
 
@@ -28,196 +30,132 @@ module.exports = function initCommand(program) {
                 if (!options.update) {
                     console.log('NodeCG is already installed in this directory.');
                     console.log('Use ' + chalk.cyan('nodecg setup [version] -u') + ' if you want update your existing install.');
-                    process.exit(0);
+                    return;
                 }
 
                 // Fetch the latest tags from GitHub
-                Q.Promise(function(resolve, reject) {
+                try {
                     process.stdout.write('Fetching the list of releases... ');
+                    execSync('git fetch');
+                    process.stdout.write(chalk.green('done!') + os.EOL);
+                } catch (e) {
+                    process.stdout.write(chalk.red('failed!') + os.EOL);
+                    console.error(e.stack);
+                    return;
+                }
 
-                    exec('git fetch', function(err, stdout, stderr) {
-                        if (err) {
-                            process.stdout.write(chalk.red('failed!') + os.EOL);
-                            reject(err);
-                            return;
-                        }
+                if (version) {
+                    process.stdout.write('Searching for release ' + chalk.magenta(version) + ' ... ');
+                } else {
+                    process.stdout.write('Checking against local install for updates... ');
+                }
 
-                        process.stdout.write(chalk.green('done!') + os.EOL);
-                        resolve();
-                    });
-                })
+                try {
+                    var tags = execSync('git tag').toString().trim().split('\n');
+                } catch (e) {
+                    process.stdout.write(chalk.red('failed!') + os.EOL);
+                    console.error(e.stack);
+                    return;
+                }
 
-                    // If [version] was supplied, check that it exists
-                    // If not, grab whatever the latest tag is
-                    .then(function() {
-                        var deferred = Q.defer();
-                        process.stderr.write = function(){}; // Shh git...
+                var current = 'v' + require(process.cwd() + '/package.json').version;
 
-                        if (version) {
-                            process.stdout.write('Searching for release '+chalk.magenta(version)+' ... ');
-                        } else {
-                            process.stdout.write('Checking against local install for updates... ');
-                        }
+                // If a version was specified, look for it in the list of tags
+                if (version && tags.indexOf(version) < 0) {
+                    process.stdout.write(chalk.red('failed!') + os.EOL);
+                    console.error('The desired release, ' + chalk.magenta(version) + ', could not be found.');
+                    return;
+                }
 
+                // Now that we know our version exists, our target is either the version or the newest tag.
+                var updatingToLatest = Boolean(!version);
+                var target = version || tags.pop();
+                process.stdout.write(chalk.green('done!') + os.EOL);
 
-                        exec('git tag', function(err, stdout, stderr) {
-                            process.stderr.write = write;
-
-                            if (err) {
-                                process.stdout.write(chalk.red('failed!') + os.EOL);
-                                deferred.reject(err);
-                                return;
-                            }
-
-                            var tags = stdout.trim().split('\n');
-                            var current = 'v' + require(process.cwd() + '/package.json').version;
-
-                            // If a version was specified, look for it in the list of tags
-                            if (version && tags.indexOf(version) < 0) {
-                                process.stdout.write(chalk.red('failed!') + os.EOL);
-                                deferred.reject(new Error('The desired release, ' + chalk.magenta(version) + ', could not be found.'));
-                            }
-
-                            // Now that we know our version exists, our target is either the version or the newest tag.
-                            var target = version || tags.pop();
-                            process.stdout.write(chalk.green('done!') + os.EOL);
-
-                            if (target < current) {
-                                console.log(chalk.red('WARNING: ') + 'The target version (%s) is older than the current version (%s)',
-                                    chalk.magenta(target), chalk.magenta(current));
-                            }
-
-                            if (target === current) {
-                                console.log('Already on version %s', chalk.magenta(current));
-                                return;
-                            }
-
-                            deferred.resolve({
-                                updatingToLatest: Boolean(!version),
-                                current: current,
-                                target: target
-                            });
-                        });
-
-                        return deferred.promise;
-                    })
-
-                    // Now that we know for sure if the target tag exists (and if its newer or older than current),
-                    // we can `git pull` and `git checkout <tag>` if appropriate.
-                    .then(function(result) {
-                        if (result.updatingToLatest && result.current >= result.latest) {
-                            console.log('No updates found! Your current version (%s) is the latest.', chalk.magenta(result.current));
-                            return;
-                        }
-
-                        var deferred = Q.defer();
-                        process.stderr.write = function(){}; // Shh git...
-                        process.stdout.write('Updating from '+chalk.magenta(result.current)+' to '+chalk.magenta(result.target)+'... ');
-                        exec('git pull origin master', function(err, stdout, stderr) {
-                            if (err) {
-                                process.stdout.write(chalk.red('failed!') + os.EOL);
-                                deferred.reject(err);
-                                return;
-                            }
-
-                            exec('git checkout ' + result.target, function(err, stdout, stderr) {
-                                process.stderr.write = write;
-
-                                if (err) {
-                                    process.stdout.write(chalk.red('failed!') + os.EOL);
-                                    deferred.reject(err);
-                                    return;
-                                }
-
-                                process.stdout.write(chalk.green('done!') + os.EOL);
-                                deferred.resolve(result.target);
-                            });
-                        });
-
-                        return deferred.promise;
-                    })
-
-                    .catch(function(e) {
-                        process.stderr.write = write;
-                        console.error('Failed to update NodeCG:', os.EOL, e.message);
-                    })
-
-                    .done(function(target) {
-                        if (target) {
-                            console.log('NodeCG updated to', chalk.magenta(target));
+                if (target < current) {
+                    console.log(chalk.red('WARNING: ') + 'The target version (%s) is older than the current version (%s)',
+                        chalk.magenta(target), chalk.magenta(current));
+                    inquirer.prompt([{
+                        name: 'installOlder',
+                        message: 'Are you sure you wish to continue?',
+                        type: 'confirm'
+                    }], function (answers) {
+                        if (answers.installOlder) {
+                            checkoutAfterFetch();
                         }
                     });
+                } else {
+                    checkoutAfterFetch();
+                }
+
                 return;
+            }
+
+            function checkoutAfterFetch() {
+                if (target === current) {
+                    console.log('Already on version %s', chalk.magenta(current));
+                    return;
+                }
+
+                if (updatingToLatest && current >= latest) {
+                    console.log('No updates found! Your current version (%s) is the latest.', chalk.magenta(current));
+                    return;
+                }
+
+                // Now that we know for sure if the target tag exists (and if its newer or older than current),
+                // we can `git pull` and `git checkout <tag>` if appropriate.
+                process.stdout.write('Updating from ' + chalk.magenta(current) + ' to ' + chalk.magenta(target) + '... ');
+                try {
+                    execSync('git pull origin master', {stdio: ['pipe', 'pipe', 'pipe']});
+                    execSync('git checkout ' + target, {stdio: ['pipe', 'pipe', 'pipe']});
+                    process.stdout.write(chalk.green('done!') + os.EOL);
+                } catch (e) {
+                    process.stdout.write(chalk.red('failed!') + os.EOL);
+                    console.error(e.stack);
+                    return;
+                }
+
+                if (target) {
+                    console.log('NodeCG updated to', chalk.magenta(target));
+                }
             }
 
             // If we're here, then NodeCG must not be installed yet.
             // Clone it into the cwd.
-            Q.Promise(function(resolve, reject) {
-                process.stdout.write('Cloning NodeCG... ');
-                process.stderr.write = function(){}; // Shh git...
+            process.stdout.write('Cloning NodeCG... ');
+            try {
+                execSync('git clone ' + NODECG_GIT_URL + ' .', {stdio: ['pipe', 'pipe', 'pipe']});
+                process.stdout.write(chalk.green('done!') + os.EOL);
+            } catch (e) {
+                process.stdout.write(chalk.red('failed!') + os.EOL);
+                console.error(e.stack);
+                return;
+            }
 
-                exec('git clone ' + NODECG_GIT_URL + ' .', function(err, stdout, stderr) {
-                    process.stderr.write = write;
-
-                    if (err) {
-                        process.stdout.write(chalk.red('failed!') + os.EOL);
-                        reject(err);
-                        return;
-                    }
-
+            // If [version] was supplied, checkout that version
+            if (version) {
+                process.stdout.write('Checking out version ' + version + '... ');
+                try {
+                    execSync('git checkout ' + version, {stdio: ['pipe', 'pipe', 'pipe']});
                     process.stdout.write(chalk.green('done!') + os.EOL);
-                    resolve();
-                });
-            })
+                } catch (e) {
+                    process.stdout.write(chalk.red('failed!') + os.EOL);
+                    console.error(e.stack);
+                    return;
+                }
+            }
 
-                // If [version] was supplied, checkout that version
-                .then(function() {
-                    if (!version) return;
+            // Install NodeCG's production depdendencies (`npm install --production`)
+            process.stdout.write('Installing production npm dependencies... ');
+            try {
+                execSync('npm install --production', { stdio: ['pipe', 'pipe', 'pipe'] });
+                process.stdout.write(chalk.green('done!') + os.EOL);
+            } catch (e) {
+                process.stdout.write(chalk.red('failed!') + os.EOL);
+                console.error(e.stack);
+                return;
+            }
 
-                    var deferred = Q.defer();
-                    process.stderr.write = function(){}; // Shh git...
-                    process.stdout.write('Checking out version ' + version + '... ');
-
-                    // If a specific version tag argument was supplied, check out that tag
-                    exec('git checkout ' + version, function(err, stdout, stderr) {
-                        process.stderr.write = write;
-
-                        if (err) {
-                            process.stdout.write(chalk.red('failed!') + os.EOL);
-                            deferred.reject(err);
-                            return;
-                        }
-
-                        process.stdout.write(chalk.green('done!') + os.EOL);
-                        deferred.resolve();
-                    });
-
-                    return deferred.promise;
-                })
-
-                // Install NodeCG's production depdendencies (`npm install --production`)
-                .then(function(){
-                    process.stdout.write('Installing production npm dependencies... ');
-                    var deferred = Q.defer();
-                    exec('npm install --production', {}, function(err, stdout, stderr) {
-                        if (err) {
-                            process.stdout.write(chalk.red('failed!') + os.EOL);
-                            deferred.reject(err);
-                            return;
-                        }
-                        process.stdout.write(chalk.green('done!') + os.EOL);
-                        deferred.resolve();
-                    });
-                    return deferred.promise;
-                })
-
-                .catch(function(e) {
-                    process.stderr.write = write;
-                   console.error('Failed to setup NodeCG:', os.EOL, e.message);
-                })
-
-                .done(function() {
-                    console.log('NodeCG (%s) installed to', version ? version : 'latest', process.cwd());
-                });
+            console.log('NodeCG (%s) installed to', version ? version : 'latest', process.cwd());
         });
 };

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -31,8 +31,6 @@ module.exports = function initCommand(program) {
                     process.exit(0);
                 }
 
-                // Fetch the latest tags
-                // Then pull the latest tag
                 Q.Promise(function(resolve, reject) {
                     process.stdout.write('Fetching the list of releases... ');
 

--- a/commands/update.js
+++ b/commands/update.js
@@ -4,15 +4,14 @@ var fs = require('fs');
 var path = require('path');
 var installDeps = require('../lib/install-deps');
 var util = require('../lib/util');
-var Q = require('q');
 var chalk = require('chalk');
 var os = require('os');
-var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
 
 module.exports = function updateCommand(program) {
     var nodecgPath = process.cwd();
 
-    function update(bundleName) {
+    function update(bundleName, installDev) {
         var bundlePath = path.join(nodecgPath, 'bundles/', bundleName);
         var manifestPath = path.join(bundlePath, 'nodecg.json');
         if (!fs.existsSync(manifestPath)) {
@@ -20,64 +19,47 @@ module.exports = function updateCommand(program) {
             process.exit(1);
         }
 
-        process.chdir(bundlePath);
-        var write = process.stderr.write;
-        Q.Promise(function(resolve, reject) {
-            process.stdout.write('Updating ' + bundleName + '... ');
+        process.stdout.write('Updating ' + bundleName + '... ');
+        try {
+            execSync('git pull', { cwd: bundlePath, stdio: ['pipe', 'pipe', 'pipe'] });
+            process.stdout.write(chalk.green('done!') + os.EOL);
+        } catch (e) {
+            process.stdout.write(chalk.red('failed!') + os.EOL);
+            console.error(e.stack);
+            return;
+        }
 
-            // Make git be quiet
-            process.stderr.write = function(){};
-
-            exec('git pull', function(err, stdout, stderr) {
-                process.stderr.write = write;
-
-                if (err) {
-                    process.stdout.write(chalk.red('failed!') + os.EOL);
-                    reject(err);
-                    return;
-                }
-
-                process.stdout.write(chalk.green('done!') + os.EOL);
-                resolve();
-            });
-        })
-            .then(function() {
-                return installDeps(bundlePath);
-            })
-            .catch(function(err) {
-                process.stderr.write = write;
-                console.error(err.message);
-                process.exit(1);
-            });
+        // After updating the bundle, install/update its npm dependencies
+        installDeps(bundlePath, installDev);
     }
 
     program
         .command('update [bundleName]')
         .description('\'git pull\' a bundle. If run with no arguments, attempts to update the bundle in the current directory (if any).')
-        .action(function(bundleName) {
+        .option('-d, --dev', 'install development dependencies')
+        .action(function(bundleName, options) {
             // TODO: this prevents this command working from within a bundle's directory
             if (!util.pathContainsNodeCG(nodecgPath)) {
                 console.error('NodeCG installation not found, are you in the right directory?');
                 process.exit(1);
             }
 
+            var dev = options.dev || false;
+
             bundleName = bundleName || path.basename(process.cwd());
 
             if (bundleName === '*') {
                 // update all bundles
-
-                // disabled for now, need to make this sync
-                return;
-
-                /*var bundlesPath = path.join(nodecgPath, 'bundles/');
+                var bundlesPath = path.join(nodecgPath, 'bundles/');
                 var bundlesPathContents = fs.readdirSync(bundlesPath);
                 bundlesPathContents.forEach(function(bundleFolderName) {
-                    if (!fs.lstatSync(bundleFolderName).isDirectory()) return;
-                    update(bundleFolderName);
-                });*/
+                    var bundlePath = path.join(bundlesPath, bundleFolderName);
+                    if (!fs.lstatSync(bundlePath).isDirectory()) return;
+                    update(bundleFolderName, dev);
+                });
             } else {
                 // update a single bundle
-                update(bundleName);
+                update(bundleName, dev);
             }
         })
 

--- a/commands/update.js
+++ b/commands/update.js
@@ -45,9 +45,7 @@ module.exports = function updateCommand(program) {
             }
 
             var dev = options.dev || false;
-
             bundleName = bundleName || path.basename(process.cwd());
-
             if (bundleName === '*') {
                 // update all bundles
                 var bundlesPath = path.join(nodecgPath, 'bundles/');

--- a/commands/update.js
+++ b/commands/update.js
@@ -23,7 +23,7 @@ module.exports = function updateCommand(program) {
         process.chdir(bundlePath);
         var write = process.stderr.write;
         Q.Promise(function(resolve, reject) {
-            process.stdout.write('Updating ' + bundleName + '...');
+            process.stdout.write('Updating ' + bundleName + '... ');
 
             // Make git be quiet
             process.stderr.write = function(){};
@@ -32,12 +32,12 @@ module.exports = function updateCommand(program) {
                 process.stderr.write = write;
 
                 if (err) {
-                    process.stdout.write(chalk.red(' failed!') + os.EOL);
+                    process.stdout.write(chalk.red('failed!') + os.EOL);
                     reject(err);
                     return;
                 }
 
-                process.stdout.write(chalk.green(' done!') + os.EOL);
+                process.stdout.write(chalk.green('done!') + os.EOL);
                 resolve();
             });
         })

--- a/lib/install-deps.js
+++ b/lib/install-deps.js
@@ -5,6 +5,9 @@ var path = require('path');
 var Q = require('q');
 var exec = require('child_process').exec;
 var semver = require('semver');
+var format = require('util').format;
+var chalk = require('chalk');
+var os = require('os');
 
 module.exports = function (bundlePath, installDev) {
     var deferred = Q.defer();
@@ -59,11 +62,15 @@ module.exports = function (bundlePath, installDev) {
 
             cmdline = 'npm install ' + toInstall.join(' ');
 
+            process.stdout.write(format('Installing dependencies (dev: %s)...', installDev));
             exec(cmdline, { cwd: bundle.dir }, function(err, stdout, stderr) {
                 if (stderr) console.error(stderr);
                 if (err) {
+                    process.stdout.write(chalk.red(' failed!') + os.EOL);
                     deferred.reject(new Error('Failed to install npm dependencies:', err.message));
+                    return;
                 }
+                process.stdout.write(chalk.green(' done!') + os.EOL);
                 deferred.resolve();
             });
         } else {

--- a/lib/install-deps.js
+++ b/lib/install-deps.js
@@ -2,16 +2,13 @@
 
 var fs = require('fs.extra');
 var path = require('path');
-var Q = require('q');
-var exec = require('child_process').exec;
 var semver = require('semver');
 var format = require('util').format;
 var chalk = require('chalk');
 var os = require('os');
+var execSync = require('child_process').execSync;
 
 module.exports = function (bundlePath, installDev) {
-    var deferred = Q.defer();
-
     var manifestPath = path.join(bundlePath, 'nodecg.json');
     if (!fs.existsSync(manifestPath)) {
         console.error('nodecg.json not found, are you sure you\'re in a bundle directory?');
@@ -23,61 +20,57 @@ module.exports = function (bundlePath, installDev) {
 
     // Check for existing dependencies
     var cmdline = 'npm ls --json --depth=0';
-    exec(cmdline, { cwd: bundle.dir }, function(err, stdout, stderr) {
-        if (stderr) console.error(stderr);
-        var data = JSON.parse(stdout);
+    try {
+        var data = JSON.parse(execSync(cmdline, { cwd: bundlePath, stdio: ['pipe', 'pipe', 'pipe'] }));
+    } catch (e) {
+        console.error(e.stack);
+        return;
+    }
 
-        var toInstall = [];
+    var toInstall = [];
 
-        // For each dependency, make an arg string and push it onto the toInstall array
-        for (var dependency in bundle.dependencies) {
-            if (!bundle.dependencies.hasOwnProperty(dependency)) continue;
+    // For each dependency, make an arg string and push it onto the toInstall array
+    for (var dependency in bundle.dependencies) {
+        if (!bundle.dependencies.hasOwnProperty(dependency)) continue;
+
+        if (!data.dependencies ||
+            !data.dependencies[dependency] ||
+            !semver.satisfies(data.dependencies[dependency].version, bundle.dependencies[dependency])) {
+            toInstall.push(dependency + '@' + bundle.dependencies[dependency]);
+        }
+    }
+
+    // If we're installing dev dependencies, do the same for those
+    if (installDev) {
+        for (dependency in bundle.devDependencies) {
+            if (!bundle.devDependencies.hasOwnProperty(dependency)) continue;
 
             if (!data.dependencies ||
                 !data.dependencies[dependency] ||
-                !semver.satisfies(data.dependencies[dependency].version, bundle.dependencies[dependency])) {
-                toInstall.push(dependency + '@' + bundle.dependencies[dependency]);
+                !semver.satisfies(data.dependencies[dependency].version, bundle.devDependencies[dependency])) {
+                toInstall.push(dependency + '@' + bundle.devDependencies[dependency]);
             }
         }
+    }
 
-        // If we're installing dev dependencies, do the same for those
-        if (installDev) {
-            for (dependency in bundle.devDependencies) {
-                if (!bundle.devDependencies.hasOwnProperty(dependency)) continue;
-
-                if (!data.dependencies ||
-                    !data.dependencies[dependency] ||
-                    !semver.satisfies(data.dependencies[dependency].version, bundle.devDependencies[dependency])) {
-                    toInstall.push(dependency + '@' + bundle.devDependencies[dependency]);
-                }
-            }
+    if (toInstall.length > 0) {
+        // Make node_modules if it doesn't exist
+        // Crucial for npm to install into the expected path
+        if (!fs.existsSync(bundlePath + '/node_modules')) {
+            fs.mkdirpSync(bundlePath + '/node_modules');
         }
 
-        if (toInstall.length > 0) {
-            // Make node_modules if it doesn't exist
-            // Crucial for npm to install into the expected path
-            if (!fs.existsSync(bundlePath + '/node_modules')) {
-                fs.mkdirpSync(bundlePath + '/node_modules');
-            }
-
-            cmdline = 'npm install ' + toInstall.join(' ');
-
-            process.stdout.write(format('Installing dependencies (dev: %s)...', installDev));
-            exec(cmdline, { cwd: bundle.dir }, function(err, stdout, stderr) {
-                if (stderr) console.error(stderr);
-                if (err) {
-                    process.stdout.write(chalk.red(' failed!') + os.EOL);
-                    deferred.reject(new Error('Failed to install npm dependencies:', err.message));
-                    return;
-                }
-                process.stdout.write(chalk.green(' done!') + os.EOL);
-                deferred.resolve();
-            });
-        } else {
-            console.log('No dependencies to install.');
-            deferred.resolve();
+        cmdline = 'npm install ' + toInstall.join(' ');
+        process.stdout.write(format('Installing dependencies (dev: %s)...', installDev));
+        try {
+            execSync(cmdline, { cwd: bundlePath, stdio: ['pipe', 'pipe', 'pipe']});
+            process.stdout.write(chalk.green('done!') + os.EOL);
+        } catch (e) {
+            process.stdout.write(chalk.red('failed!') + os.EOL);
+            console.error(e.stack);
+            return;
         }
-    });
-
-    return deferred.promise;
+    } else {
+        console.log('No dependencies to install.');
+    }
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "nodecg": "bin/nodecg"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "preferGlobal": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodecg-cli",
   "description": "The NodeCG command line interface.",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/nodecg/nodecg-cli.git"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "fs.extra": "^1.3.2",
     "inquirer": "^0.8.0",
     "npm-package-arg": "^3.0.0",
-    "q": "^1.1.2",
     "request": "^2.51.0",
     "semver": "^4.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "commander": "^2.6.0",
     "fs.extra": "^1.3.2",
     "inquirer": "^0.8.0",
-    "nodegit": "^0.2.7",
     "npm-package-arg": "^3.0.0",
     "q": "^1.1.2",
     "request": "^2.51.0",


### PR DESCRIPTION
- Removed dependency on nodegit, in favor of invoking `git` directly.
 - This means that `git` must now be present in your PATH.
 - Installing nodecg-cli no longer requires compiling nodegit.
- Added `--update` flag to `nodecg setup`, to update an existing NodeCG install
- nodecg-cli now makes heavy use of `execSync`, meaning that it requires node.js v0.12.0 or greater.