### PR TITLE
feat: make installation of Bower deps optional

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -163,13 +163,15 @@ function installDependencies() {
 		return;
 	}
 
-	process.stdout.write('Installing production bower dependencies... ');
-	try {
-		execSync('bower install --production', {stdio: ['pipe', 'pipe', 'pipe']});
-		process.stdout.write(chalk.green('done!') + os.EOL);
-	} catch (e) {
-		process.stdout.write(chalk.red('failed!') + os.EOL);
-		console.error(e.stack);
+	if (fs.existsSync('./bower.json')) {
+		process.stdout.write('Installing production bower dependencies... ');
+		try {
+			execSync('bower install --production', {stdio: ['pipe', 'pipe', 'pipe']});
+			process.stdout.write(chalk.green('done!') + os.EOL);
+		} catch (e) {
+			process.stdout.write(chalk.red('failed!') + os.EOL);
+			console.error(e.stack);
+		}
 	}
 }
 


### PR DESCRIPTION
NodeCG is soon to remove its dependency on Bower entirely, so there might not be a `bower.json` present when setting up a new NodeCG instance. Therefore, we must check for the presence of a `bower.json` file before attempting to run `bower install`.