### PR TITLE
fix: more explicit .gitattributes to for LF line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 * text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf


### PR DESCRIPTION
This *probably* fixes the problem of `env: node\r: No such file or directory` error when nodecg-cli is installed with Yarn on unix.

Related:
- https://github.com/npm/npm/issues/12371
- https://github.com/yarnpkg/yarn/issues/5480