### PR TITLE
feat(schema-types): generate index.d.ts which exports all types

### DIFF
--- a/src/commands/schema-types.ts
+++ b/src/commands/schema-types.ts
@@ -67,7 +67,11 @@ function action(inDir: string, cmd: {outDir: string, configSchema: boolean}) {
 		);
 	}
 
+	const indexFiles = [];
+
 	for (const schema of schemas) {
+		indexFiles.push(`export * from './${schema.replace(/\.json$/i, '')}';`);
+
 		compile(
 			path.resolve(schemasDir, schema),
 			path.resolve(outDir, schema.replace(/\.json$/i, '.d.ts')),
@@ -75,7 +79,9 @@ function action(inDir: string, cmd: {outDir: string, configSchema: boolean}) {
 		);
 	}
 
-	return Promise.all(compilePromises).then(() => {
+	const indexPromise = writeFilePromise(path.resolve(outDir, 'index.d.ts'), `${indexFiles.join('\n')}\n`);
+
+	return Promise.all([indexPromise, ...compilePromises]).then(() => {
 		process.emit('schema-types-done');
 	});
 }

--- a/test/commands/5_schema-types.mspec.js
+++ b/test/commands/5_schema-types.mspec.js
@@ -31,7 +31,7 @@ describe('schema-types command', () => {
 		new SchemaTypesCommand(program); // eslint-disable-line no-new
 	});
 
-	it('should successfully create d.ts files from the replicant schemas', async () => {
+	it('should successfully create d.ts files from the replicant schemas and create an index.d.ts file', async () => {
 		process.chdir('bundles/schema-types');
 		program.runWith('schema-types');
 
@@ -56,6 +56,16 @@ describe('schema-types command', () => {
 		assert.equal(
 			fs.readFileSync(outputPath, 'utf8'),
 			fs.readFileSync('../../results/schema-types/example.d.ts', 'utf8')
+		);
+
+		const indexPath = './src/types/schemas/index.d.ts';
+		assert.isTrue(
+			fs.existsSync(indexPath)
+		);
+
+		assert.equal(
+			fs.readFileSync(indexPath, 'utf8'),
+			fs.readFileSync('../../results/schema-types/index.d.ts', 'utf8')
 		);
 	});
 

--- a/test/fixtures/results/schema-types/index.d.ts
+++ b/test/fixtures/results/schema-types/index.d.ts
@@ -1,0 +1,1 @@
+export * from './example';


### PR DESCRIPTION
Allows types to be imported more elegantly, e.g. `import { example } from './types';`

Taken from zoton2's template bundle [here](https://github.com/zoton2/nodecg-vue-ts-template/blob/master/script/typeschemas.js#L29-L34).