### PR TITLE
wip: Fix broken setup downgrade prompt on windows 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chalk": "2.4.2",
     "commander": "2.19.0",
     "fs-extra": "7.0.1",
-    "inquirer": "6.2.1",
+    "inquirer": "^7.0.0",
     "json-schema-defaults": "0.3.0",
     "json-schema-to-typescript": "6.1.0",
     "npm-package-arg": "6.1.0",

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -104,7 +104,7 @@ function action(version: string, options: {update: boolean, skipDependencies: bo
 				name: 'installOlder',
 				message: 'Are you sure you wish to continue?',
 				type: 'confirm'
-			}], answers => {
+			}]).then(answers => {
 				if (answers.installOlder) {
 					checkoutUpdate(current, target, options.skipDependencies, true);
 				}


### PR DESCRIPTION
Unsure if the issue was present on other OSs, but the prompt never resolved the callback previously. Updating `inquirer` and moving to promises _seems_ to have fixed the issue, but WIP because tests fail.

Reported by @kurt#8243 in the discord.