### PR TITLE
refactor(setup): remove support for nodecg less than 2.0.0

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,8 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import semver from "semver";
-
 import type { NpmRelease } from "./sample/npm-release.js";
 
 /**
@@ -66,25 +64,6 @@ export function getCurrentNodeCGVersion(): string {
 	const nodecgPath = getNodeCGPath();
 	return JSON.parse(fs.readFileSync(`${nodecgPath}/package.json`, "utf8"))
 		.version;
-}
-
-/**
- * Gets the latest NodeCG release information from npm, including tarball download link.
- */
-export async function getNodeCGRelease(target: string): Promise<NpmRelease> {
-	const targetVersion = semver.coerce(target)?.version;
-	if (!targetVersion) {
-		throw new Error(`Failed to determine target NodeCG version`);
-	}
-
-	const res = await fetch(`http://registry.npmjs.org/nodecg/${targetVersion}`);
-	if (res.status !== 200) {
-		throw new Error(
-			`Failed to fetch NodeCG release information from npm, status code ${res.status}`,
-		);
-	}
-
-	return res.json() as Promise<NpmRelease>;
 }
 
 export async function getLatestCLIRelease(): Promise<NpmRelease> {


### PR DESCRIPTION
BREAKING CHANGE: Drop support for nodecg 0.x.x and 1.x.x.